### PR TITLE
do not return error when min qty not passed

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -29,6 +29,10 @@ type BotOrderAdjusted struct {
 
 	// optional
 	ClientOrderID string `json:"clientOrderID"`
+
+	// additional
+	MinQty       float64 `json:"minQty"`
+	MinQtyPassed bool    `json:"minQtyPassed"`
 }
 
 // CreateOrderResponse ..

--- a/structs.go
+++ b/structs.go
@@ -30,9 +30,11 @@ type BotOrderAdjusted struct {
 	// optional
 	ClientOrderID string `json:"clientOrderID"`
 
-	// additional
-	MinQty       float64 `json:"minQty"`
-	MinQtyPassed bool    `json:"minQtyPassed"`
+	// calculated
+	MinQty           float64 `json:"minQty"`
+	MinQtyPassed     bool    `json:"minQtyPassed"`
+	MinDeposit       float64 `json:"minDeposit"`
+	MinDepositPassed bool    `json:"minDepositPassed"`
 }
 
 // CreateOrderResponse ..

--- a/utils.go
+++ b/utils.go
@@ -75,13 +75,13 @@ func RoundPairOrderValues(order BotOrder, pairLimits ExchangePairData) (BotOrder
 		PairSymbol:    order.PairSymbol,
 		Type:          order.Type,
 		ClientOrderID: order.ClientOrderID,
+		MinQty:        pairLimits.MinQty,
+		MinQtyPassed:  true,
 	}
 
 	// check lot size
 	if order.Qty < pairLimits.MinQty {
-		return result, errors.New("insufficient amount to open an order in this pair. " +
-			"order qty: " + strconv.FormatFloat(order.Qty, 'f', 8, 32) +
-			" min: " + strconv.FormatFloat(pairLimits.MinQty, 'f', 8, 32))
+		result.MinQtyPassed = false
 	}
 	if order.Qty > pairLimits.MaxQty {
 		return result, errors.New("too much amount to open an order in this pair. " +

--- a/utils.go
+++ b/utils.go
@@ -213,10 +213,6 @@ func GetDefaultPairData() ExchangePairData {
 	}
 }
 
-func floatToString(val float64) string {
-	return strconv.FormatFloat(val, 'f', 8, 64)
-}
-
 // RoundMinDeposit - update the value of the minimum deposit in accordance with the minimum threshold
 func RoundMinDeposit(pairMinDeposit float64) float64 {
 	return pairMinDeposit * (1 + MinDepositFix/100)

--- a/utils.go
+++ b/utils.go
@@ -72,11 +72,13 @@ func OrderDataToBotOrder(order OrderData) BotOrder {
 // RoundPairOrderValues - adjusts the order values in accordance with the trading pair parameters
 func RoundPairOrderValues(order BotOrder, pairLimits ExchangePairData) (BotOrderAdjusted, error) {
 	result := BotOrderAdjusted{
-		PairSymbol:    order.PairSymbol,
-		Type:          order.Type,
-		ClientOrderID: order.ClientOrderID,
-		MinQty:        pairLimits.MinQty,
-		MinQtyPassed:  true,
+		PairSymbol:       order.PairSymbol,
+		Type:             order.Type,
+		ClientOrderID:    order.ClientOrderID,
+		MinQty:           pairLimits.MinQty,
+		MinQtyPassed:     true, // by default
+		MinDeposit:       pairLimits.OriginalMinDeposit,
+		MinDepositPassed: true, // by default
 	}
 
 	// check lot size
@@ -97,8 +99,7 @@ func RoundPairOrderValues(order BotOrder, pairLimits ExchangePairData) (BotOrder
 	// check min deposit
 	orderDeposit := order.Qty * order.Price
 	if orderDeposit < pairLimits.OriginalMinDeposit {
-		return result, errors.New("the order deposit (" + floatToString(orderDeposit) + ") is less than the minimum: " +
-			floatToString(pairLimits.OriginalMinDeposit))
+		result.MinDepositPassed = false
 	}
 
 	// round order values


### PR DESCRIPTION
теперь для работы с TP в core надо проверять, когда не хватает минимального числа монет и депозита на TP. чтобы игнорировать срабатывание ордера, когда на переставление TP не хватает депозита.
проверять ошибку, полученную от exchange-gates было бы слишком костыльно. пришлось тут сделать это как bool параметрами, что такие-то проверки не прошли