### PR TITLE
fix integer round

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -77,6 +77,10 @@ func RoundFloatFloor(val float64, precision int) (float64, error) {
 }
 
 func formatFloatFloor(val float64, precision int) (string, error) {
+	if precision == 0 {
+		return strconv.FormatFloat(val, 'f', 0, 64), nil
+	}
+
 	valRounded, err := RoundFloatFloor(val, precision)
 	if err != nil {
 		return "", fmt.Errorf("round value: %w", err)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -21,6 +21,18 @@ func TestGetFloatPrecision(t *testing.T) {
 	}
 }
 
+func TestGetFloatPrecision2(t *testing.T) {
+	// given
+	var val float64 = 30
+	var precisionExpected int = 0
+
+	// when
+	var precision = GetFloatPrecision(val)
+
+	// then
+	assert.Equal(t, precisionExpected, precision)
+}
+
 func TestOrderResponseToBotOrder(t *testing.T) {
 	fromOrder := structs.CreateOrderResponse{}
 
@@ -90,7 +102,21 @@ func TestFormatFloatFloor(t *testing.T) {
 	assert.Equal(t, qtyFormatedExpected, qtyFormated)
 }
 
-func TestRoundFloatFloor1(t *testing.T) {
+func TestFormatFloatFloor2(t *testing.T) {
+	// given
+	qty := float64(30)
+	precision := 0
+	qtyFormatedExpected := "30"
+
+	// when
+	qtyFormated, err := formatFloatFloor(qty, precision)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, qtyFormatedExpected, qtyFormated)
+}
+
+func TestRoundFloatFloor(t *testing.T) {
 	// given
 	val := float64(0.00053)
 	precision := int(5)


### PR DESCRIPTION
для числа 30 определялось, что precision = 0. и когда шло округление, происходила какая-то хрень.
теперь, если precision 0, значит можно не округлять, а просто выдать как есть