### PR TITLE
add qty round test

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -86,10 +86,14 @@ func formatFloatFloor(val float64, precision int) (string, error) {
 		return "", fmt.Errorf("round value: %w", err)
 	}
 
-	return strings.TrimRight(
+	v := strings.TrimRight(
 		strconv.FormatFloat(valRounded, 'f', precision, 64),
 		".0",
-	), nil
+	)
+	if v == "" {
+		return "0", nil
+	}
+	return v, nil
 }
 
 /*

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -130,6 +130,20 @@ func TestFormatFloatFloor3(t *testing.T) {
 	assert.Equal(t, qtyFormatedExpected, qtyFormated)
 }
 
+func TestFormatFloatFloor4(t *testing.T) {
+	// given
+	qty := float64(4.0000000000000295e-07)
+	precision := 3
+	qtyFormatedExpected := "0"
+
+	// when
+	qtyFormated, err := formatFloatFloor(qty, precision)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, qtyFormatedExpected, qtyFormated)
+}
+
 func TestRoundFloatFloor(t *testing.T) {
 	// given
 	val := float64(0.00053)


### PR DESCRIPTION
если qty на порядок меньше чем ожидаемое число после запятой в значении, то некорректно производилось форматирование, получалась пустая строка. в этом случае будет возвращаться "0"