### PR TITLE
remove pair data from `RoundDeposit` func

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -170,10 +170,14 @@ func RoundPairOrderValues(
 	return result, nil
 }
 
-// RoundDeposit - round deposit for grid by pair limits
-func RoundDeposit(deposit float64, pairLimits structs.ExchangePairData) (float64, error) {
-	depositStep := pairLimits.PriceStep * pairLimits.QtyStep
-	depositRoundedStr := strconv.FormatFloat(deposit, 'f', GetFloatPrecision(depositStep), 64)
+// RoundDeposit - round deposit. tickerValueStep - minimum value step
+func RoundDeposit(deposit float64, tickerValueStep float64) (float64, error) {
+	depositRoundedStr := strconv.FormatFloat(
+		deposit,
+		'f',
+		GetFloatPrecision(tickerValueStep),
+		64,
+	)
 	depositRounded, err := strconv.ParseFloat(depositRoundedStr, 64)
 	if err != nil {
 		return 0, fmt.Errorf("round deposit: %w", err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -171,7 +171,7 @@ func RoundPairOrderValues(
 }
 
 // RoundDeposit - round deposit. tickerValueStep - minimum value step
-func RoundDeposit(deposit float64, tickerValueStep float64) (float64, error) {
+func RoundDeposit(deposit, tickerValueStep float64) (float64, error) {
 	depositRoundedStr := strconv.FormatFloat(
 		deposit,
 		'f',

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -291,3 +291,42 @@ func TestCalcTPOrderLong(t *testing.T) {
 	assert.Equal(t, float64(0.00126), order.Qty)
 	assert.Equal(t, pkgStructs.OrderTypeSell, order.Type)
 }
+
+func TestRoundDeposit(t *testing.T) {
+	// given
+	deposit := float64(100.1)
+	depositStep := float64(0.00001)
+
+	// when
+	roundedDeposit, err := RoundDeposit(deposit, depositStep)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, float64(100.1), roundedDeposit)
+}
+
+func TestRoundDeposit2(t *testing.T) {
+	// given
+	deposit := float64(100.1)
+	depositStep := float64(0.1)
+
+	// when
+	roundedDeposit, err := RoundDeposit(deposit, depositStep)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, float64(100.1), roundedDeposit)
+}
+
+func TestRoundDeposit3(t *testing.T) {
+	// given
+	deposit := float64(100.1)
+	depositStep := float64(0)
+
+	// when
+	roundedDeposit, err := RoundDeposit(deposit, depositStep)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, float64(100), roundedDeposit)
+}


### PR DESCRIPTION
1. слишком жирно передавать в этот метод целую структуру, из которой используется всего одно поле. заменил на конкретный аргумент функции.
2. пусть вызывающий функцию определяет какое значение взять за deposit value step. так как это зависит от стратегии (long/short). например, если пара BTCBUSD, для long депо в BUSD (depo step = ???, пусть будет price step * qty step), для short - в BTC (depo step = qty step).