### PR TITLE
init bybit trade events worker go-channels

### DIFF
--- a/internal/adapters/bybit/subscription.go
+++ b/internal/adapters/bybit/subscription.go
@@ -3,6 +3,7 @@ package bybit
 import (
 	"github.com/matrixbotio/exchange-gates-lib/internal/adapters/bybit/helpers"
 	"github.com/matrixbotio/exchange-gates-lib/internal/workers"
+	"github.com/matrixbotio/exchange-gates-lib/pkg/structs"
 )
 
 func (a *adapter) GetPriceWorker(callback workers.PriceEventCallback) workers.IPriceWorker {
@@ -21,7 +22,9 @@ func (a *adapter) GetCandleWorker() workers.ICandleWorker {
 }
 
 func (a *adapter) GetTradeEventsWorker() workers.ITradeEventWorker {
-	return &TradeEventWorkerBybit{
+	w := &TradeEventWorkerBybit{
 		wsClient: a.wsClient,
 	}
+	w.TradeEventWorker.WsChannels = new(structs.WorkerChannels)
+	return w
 }


### PR DESCRIPTION
просто обновление заглушки этого воркера. когда marketdata будет обновлена, здесь воркер обновится.

marketdata падала, так как для заглушки trade event worker к bybit не была задана одна структура