### PR TITLE
store order fee in struct

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -6,7 +6,6 @@ import (
 	"github.com/matrixbotio/exchange-gates-lib/internal/structs"
 	"github.com/matrixbotio/exchange-gates-lib/internal/workers"
 	pkgStructs "github.com/matrixbotio/exchange-gates-lib/pkg/structs"
-	"github.com/shopspring/decimal"
 )
 
 type Adapter interface {
@@ -29,7 +28,11 @@ type Adapter interface {
 		ctx context.Context,
 		order structs.BotOrderAdjusted,
 	) (structs.CreateOrderResponse, error)
-	GetOrderExecFee(pairSymbol string, orderID int64) (decimal.Decimal, error)
+	GetOrderExecFee(
+		pairSymbol string,
+		orderSide string,
+		orderID int64,
+	) (structs.OrderFees, error)
 
 	// Pair
 	GetPairData(pairSymbol string) (structs.ExchangePairData, error)

--- a/internal/adapters/binance/order.go
+++ b/internal/adapters/binance/order.go
@@ -1,8 +1,19 @@
 package binance
 
-import "github.com/shopspring/decimal"
+import (
+	"github.com/matrixbotio/exchange-gates-lib/internal/structs"
+	"github.com/shopspring/decimal"
+)
 
-func (a *adapter) GetOrderExecFee(pairSymbol string, orderID int64) (decimal.Decimal, error) {
+func (a *adapter) GetOrderExecFee(
+	pairSymbol string,
+	orderSide string,
+	orderID int64,
+) (structs.OrderFees, error) {
 	// TBD: https://github.com/matrixbotio/exchange-gates-lib/issues/167
-	return decimal.NewFromInt(0), nil
+
+	return structs.OrderFees{
+		BaseAsset:  decimal.NewFromInt(0),
+		QuoteAsset: decimal.NewFromInt(0),
+	}, nil
 }

--- a/internal/adapters/bybit/helpers/mappers/order/order_parser_test.go
+++ b/internal/adapters/bybit/helpers/mappers/order/order_parser_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 
 	"github.com/hirokisan/bybit/v2"
+	pkgStructs "github.com/matrixbotio/exchange-gates-lib/pkg/structs"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseOrderExecFee(t *testing.T) {
+func TestParseBuyOrderExecFee(t *testing.T) {
 	// given
+	orderSide := pkgStructs.OrderTypeBuy
 	orderExecData := bybit.V5GetExecutionListResult{
 		List: []bybit.V5GetExecutionListItem{
 			{
@@ -24,15 +26,41 @@ func TestParseOrderExecFee(t *testing.T) {
 	}
 
 	// when
-	fees, err := ParseOrderExecFee(orderExecData)
+	fees, err := ParseOrderExecFee(orderExecData, orderSide)
 
 	// then
 	require.NoError(t, err)
-	assert.Equal(t, decimal.NewFromFloat(float64(0.000144)), fees)
+	assert.Equal(t, decimal.NewFromFloat(float64(0.000144)), fees.BaseAsset)
+	assert.Equal(t, decimal.NewFromFloat(0), fees.QuoteAsset)
+}
+
+func TestParseSellOrderExecFee(t *testing.T) {
+	// given
+	orderSide := pkgStructs.OrderTypeSell
+	orderExecData := bybit.V5GetExecutionListResult{
+		List: []bybit.V5GetExecutionListItem{
+			{
+				OrderQty: "0.124",
+				ExecFee:  "0.000124",
+			},
+			{
+				ExecFee: "0.00002",
+			},
+		},
+	}
+
+	// when
+	fees, err := ParseOrderExecFee(orderExecData, orderSide)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, decimal.NewFromFloat(float64(0.000144)), fees.QuoteAsset)
+	assert.Equal(t, decimal.NewFromFloat(0), fees.BaseAsset)
 }
 
 func TestParseOrderExecFeeZero(t *testing.T) {
 	// given
+	orderSide := pkgStructs.OrderTypeBuy
 	orderExecData := bybit.V5GetExecutionListResult{
 		List: []bybit.V5GetExecutionListItem{
 			{
@@ -44,9 +72,10 @@ func TestParseOrderExecFeeZero(t *testing.T) {
 	}
 
 	// when
-	fees, err := ParseOrderExecFee(orderExecData)
+	fees, err := ParseOrderExecFee(orderExecData, orderSide)
 
 	// then
 	require.NoError(t, err)
-	assert.Equal(t, decimal.NewFromFloat(float64(0)), fees)
+	assert.Equal(t, decimal.NewFromFloat(float64(0)), fees.BaseAsset)
+	assert.Equal(t, decimal.NewFromFloat(float64(0)), fees.QuoteAsset)
 }

--- a/internal/adapters/mock_adapter.go
+++ b/internal/adapters/mock_adapter.go
@@ -6,8 +6,6 @@ import (
 	context "context"
 
 	internalstructs "github.com/matrixbotio/exchange-gates-lib/internal/structs"
-	decimal "github.com/shopspring/decimal"
-
 	mock "github.com/stretchr/testify/mock"
 
 	structs "github.com/matrixbotio/exchange-gates-lib/pkg/structs"
@@ -549,23 +547,23 @@ func (_c *MockAdapter_GetOrderData_Call) RunAndReturn(run func(string, int64) (i
 	return _c
 }
 
-// GetOrderExecFee provides a mock function with given fields: pairSymbol, orderID
-func (_m *MockAdapter) GetOrderExecFee(pairSymbol string, orderID int64) (decimal.Decimal, error) {
-	ret := _m.Called(pairSymbol, orderID)
+// GetOrderExecFee provides a mock function with given fields: pairSymbol, orderSide, orderID
+func (_m *MockAdapter) GetOrderExecFee(pairSymbol string, orderSide string, orderID int64) (internalstructs.OrderFees, error) {
+	ret := _m.Called(pairSymbol, orderSide, orderID)
 
-	var r0 decimal.Decimal
+	var r0 internalstructs.OrderFees
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, int64) (decimal.Decimal, error)); ok {
-		return rf(pairSymbol, orderID)
+	if rf, ok := ret.Get(0).(func(string, string, int64) (internalstructs.OrderFees, error)); ok {
+		return rf(pairSymbol, orderSide, orderID)
 	}
-	if rf, ok := ret.Get(0).(func(string, int64) decimal.Decimal); ok {
-		r0 = rf(pairSymbol, orderID)
+	if rf, ok := ret.Get(0).(func(string, string, int64) internalstructs.OrderFees); ok {
+		r0 = rf(pairSymbol, orderSide, orderID)
 	} else {
-		r0 = ret.Get(0).(decimal.Decimal)
+		r0 = ret.Get(0).(internalstructs.OrderFees)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, int64) error); ok {
-		r1 = rf(pairSymbol, orderID)
+	if rf, ok := ret.Get(1).(func(string, string, int64) error); ok {
+		r1 = rf(pairSymbol, orderSide, orderID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -580,24 +578,25 @@ type MockAdapter_GetOrderExecFee_Call struct {
 
 // GetOrderExecFee is a helper method to define mock.On call
 //   - pairSymbol string
+//   - orderSide string
 //   - orderID int64
-func (_e *MockAdapter_Expecter) GetOrderExecFee(pairSymbol interface{}, orderID interface{}) *MockAdapter_GetOrderExecFee_Call {
-	return &MockAdapter_GetOrderExecFee_Call{Call: _e.mock.On("GetOrderExecFee", pairSymbol, orderID)}
+func (_e *MockAdapter_Expecter) GetOrderExecFee(pairSymbol interface{}, orderSide interface{}, orderID interface{}) *MockAdapter_GetOrderExecFee_Call {
+	return &MockAdapter_GetOrderExecFee_Call{Call: _e.mock.On("GetOrderExecFee", pairSymbol, orderSide, orderID)}
 }
 
-func (_c *MockAdapter_GetOrderExecFee_Call) Run(run func(pairSymbol string, orderID int64)) *MockAdapter_GetOrderExecFee_Call {
+func (_c *MockAdapter_GetOrderExecFee_Call) Run(run func(pairSymbol string, orderSide string, orderID int64)) *MockAdapter_GetOrderExecFee_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(int64))
+		run(args[0].(string), args[1].(string), args[2].(int64))
 	})
 	return _c
 }
 
-func (_c *MockAdapter_GetOrderExecFee_Call) Return(_a0 decimal.Decimal, _a1 error) *MockAdapter_GetOrderExecFee_Call {
+func (_c *MockAdapter_GetOrderExecFee_Call) Return(_a0 internalstructs.OrderFees, _a1 error) *MockAdapter_GetOrderExecFee_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockAdapter_GetOrderExecFee_Call) RunAndReturn(run func(string, int64) (decimal.Decimal, error)) *MockAdapter_GetOrderExecFee_Call {
+func (_c *MockAdapter_GetOrderExecFee_Call) RunAndReturn(run func(string, string, int64) (internalstructs.OrderFees, error)) *MockAdapter_GetOrderExecFee_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/adapters/test/adapter.go
+++ b/internal/adapters/test/adapter.go
@@ -172,6 +172,13 @@ func (a *adapter) GetAccountBalance() ([]structs.Balance, error) {
 	return nil, nil
 }
 
-func (a *adapter) GetOrderExecFee(pairSymbol string, orderID int64) (decimal.Decimal, error) {
-	return decimal.NewFromInt(0), nil
+func (a *adapter) GetOrderExecFee(
+	pairSymbol string,
+	orderSide string,
+	orderID int64,
+) (structs.OrderFees, error) {
+	return structs.OrderFees{
+		BaseAsset:  decimal.NewFromInt(0),
+		QuoteAsset: decimal.NewFromInt(0),
+	}, nil
 }

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -1,6 +1,10 @@
 package structs
 
-import "context"
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+)
 
 // BotOrderAdjusted - the same as BotOrder, only with the given values for the trading pair
 type BotOrderAdjusted struct {
@@ -121,4 +125,9 @@ type GetOrdersHistoryTask struct {
 type SymbolPrice struct {
 	Symbol string  `json:"symbol"`
 	Price  float64 `json:"price"`
+}
+
+type OrderFees struct {
+	BaseAsset  decimal.Decimal `json:"base"`
+	QuoteAsset decimal.Decimal `json:"quote"`
 }

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -21,6 +21,7 @@ type (
 	PairBalance          = structs.PairBalance
 	PairSymbolData       = structs.PairSymbolData
 	AssetBalance         = structs.AssetBalance
+	OrderFees            = structs.OrderFees
 )
 
 type (


### PR DESCRIPTION
Depending on the type of order on Bybit, the commission is charged in different coins.
For `buy` orders - in `base` asset. For `sell` orders - in `quote` asset,
So I had to put it into a structure.

![ustal](https://i.mycdn.me/i?r=AzEPZsRbOZEKgBhR0XGMT1Rk1zB3T6IuWRGAyRHH2Ca7faaKTM5SRkZCeTgDn6uOyic)