### PR TITLE
fix: ignore error when order not found

### DIFF
--- a/internal/adapters/bybit/helpers/errs/helpers.go
+++ b/internal/adapters/bybit/helpers/errs/helpers.go
@@ -22,6 +22,9 @@ func HandleCancelOrderError(
 	if strings.Contains(err.Error(), errs.ErrOrderFilled.Error()) {
 		return errs.ErrOrderFilled
 	}
+	if strings.Contains(err.Error(), "Order does not exist") {
+		return nil
+	}
 
 	return fmt.Errorf(
 		"cancel order %s in %q: %w",


### PR DESCRIPTION
When an old TP order is canceled, if it is not active, then bybit gives an error that it was not found. In this case, we will not issue an error.