### PR TITLE
add `IsTradeEventUsed` method

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -74,4 +74,9 @@ type Adapter interface {
 
 	// CANDLE
 	GetCandles(limit int, symbol string, interval string) ([]workers.CandleData, error)
+
+	IsTradeEventUsed(
+		workers.TradeEvent,
+		workers.TradeEventPartialFilledData,
+	) bool
 }

--- a/internal/adapters/binance/adapter.go
+++ b/internal/adapters/binance/adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	adp "github.com/matrixbotio/exchange-gates-lib/internal/adapters"
+	"github.com/matrixbotio/exchange-gates-lib/internal/adapters/binance/helpers"
 	"github.com/matrixbotio/exchange-gates-lib/internal/adapters/binance/helpers/errs"
 	"github.com/matrixbotio/exchange-gates-lib/internal/adapters/binance/workers"
 	"github.com/matrixbotio/exchange-gates-lib/internal/adapters/binance/wrapper"
@@ -77,4 +78,17 @@ func (a *adapter) GetTradeEventsWorker() iWorkers.ITradeEventWorker {
 		a.GetTag(),
 		a.binanceAPI,
 	)
+}
+
+func (a *adapter) IsTradeEventUsed(
+	event iWorkers.TradeEvent,
+	handledParts iWorkers.TradeEventPartialFilledData,
+) bool {
+	if len(handledParts) == 0 {
+		return false
+	}
+
+	cacheKey := helpers.GetTradeEventCacheKey(event.BuyerOrderID, event.SellerOrderID)
+	_, isEventUsed := handledParts[cacheKey]
+	return isEventUsed
 }

--- a/internal/adapters/binance/helpers/helpers.go
+++ b/internal/adapters/binance/helpers/helpers.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"fmt"
+)
+
+func GetTradeEventCacheKey(buyerOrderID, sellerOrderID int64) string {
+	return fmt.Sprintf(
+		"%v-%v",
+		buyerOrderID,
+		sellerOrderID,
+	)
+}

--- a/internal/adapters/bybit/events.go
+++ b/internal/adapters/bybit/events.go
@@ -86,3 +86,10 @@ func (w *PriceEventWorkerBybit) SubscribeToPriceEvents(
 
 	return result, nil
 }
+
+func (a *adapter) IsTradeEventUsed(
+	_ workers.TradeEvent,
+	_ workers.TradeEventPartialFilledData,
+) bool {
+	return false
+}

--- a/internal/adapters/bybit/events.go
+++ b/internal/adapters/bybit/events.go
@@ -87,6 +87,11 @@ func (w *PriceEventWorkerBybit) SubscribeToPriceEvents(
 	return result, nil
 }
 
+/*
+TBD: implement this method after
+the realtime stream of trading events from the exchange is connected
+https://github.com/matrixbotio/exchange-gates-lib/issues/153
+*/
 func (a *adapter) IsTradeEventUsed(
 	_ workers.TradeEvent,
 	_ workers.TradeEventPartialFilledData,

--- a/internal/adapters/test/adapter.go
+++ b/internal/adapters/test/adapter.go
@@ -181,3 +181,10 @@ func (a *adapter) GetOrderExecFee(
 		QuoteAsset: decimal.NewFromInt(0),
 	}, nil
 }
+
+func (a *adapter) IsTradeEventUsed(
+	workers.TradeEvent,
+	workers.TradeEventPartialFilledData,
+) bool {
+	return false
+}

--- a/internal/workers/trade.go
+++ b/internal/workers/trade.go
@@ -54,3 +54,5 @@ type TradeEvent struct {
 	BuyerOrderID  int64   `json:"buyerID"`
 	SellerOrderID int64   `json:"sellerID"`
 }
+
+type TradeEventPartialFilledData map[string]struct{}


### PR DESCRIPTION
1. Behavior with duplicate trading events had to be divided into adapters. For Bybit this is not relevant yet, so there is only a method stub, but for binance it is as it was.
2. Less logic in core is better