### PR TITLE
fix order data filled check according to qty

### DIFF
--- a/internal/structs/order_data.go
+++ b/internal/structs/order_data.go
@@ -29,12 +29,11 @@ func (data OrderData) IsExpired() bool {
 }
 
 func (data OrderData) IsPartiallyFilled() bool {
-	return data.Status == consts.OrderStatusPartiallyFilled ||
-		data.Status == consts.OrderStatusPartiallyFilledCancelled
+	return data.FilledQty < data.AwaitQty
 }
 
 func (data OrderData) IsFullFilled() bool {
-	return data.Status == consts.OrderStatusFilled
+	return data.FilledQty == data.AwaitQty
 }
 
 func (data OrderData) IsPartiallyOrFullFilled() bool {


### PR DESCRIPTION
We don’t work with statuses everywhere, especially in tests.
It is better to determine whether an order is executed by the number of coins.